### PR TITLE
Thread instance number through typing relations

### DIFF
--- a/IndexModuleTyping.rkt
+++ b/IndexModuleTyping.rkt
@@ -13,70 +13,77 @@
 
 ;; Validates the function definition and returns all exports and the type of the function
 (define-judgment-form WASMIndexTypes
-  #:contract (⊢-module-func S C f ((ex ...) tfi))
+  #:contract (⊢-module-func S i C f ((ex ...) tfi))
 
   ;; Should (t _) ... be instiantiated in phi_1?
   [(where ((((t_1 a) ...) () globals_1 φ_1) -> ((ti_2 ...) () globals_2 φ_2)) tfi)
    (where ((_ t_2) ...) (tg ...))
-   (⊢ S ((func (tfi_1 ...)) (global (tg ...)) (table (j_1 (i ...)) ...) (memory j_2 ...) (local (t_1 ... t ...)) (label (((ti_2 ...) _ globals_2 φ_2))) (return ((ti_2 ...) _ globals_2 φ_2)))
+   (⊢ S i
+      ((func (tfi_1 ...))
+       (global (tg ...))
+       (table (j_1 (i_1 ...)) ...)
+       (memory j_2 ...)
+       (local (t_1 ... t ...))
+       (label (((ti_2 ...) _ globals_2 φ_2)))
+       (return ((ti_2 ...) _ globals_2 φ_2)))
       (e ...)
       ((() ((t_1 a) ... (t _) ...) globals_1 φ_1) -> ((ti_2 ...) _ ((t_2 a_2) ...) φ_2)))
    ;; a_2 ... fresh
    --------------------------------------------------------------------------------------
-   (⊢-module-func S ((func (tfi_1 ...)) (global (tg ...)) (table (j_1 (i ...)) ...) (memory j_2 ...) _ _ _)
+   (⊢-module-func S i ((func (tfi_1 ...)) (global (tg ...)) (table (j_1 (i_1 ...)) ...) (memory j_2 ...) _ _ _)
                   ((ex ...) (func tfi (local (t ...) (e ...))))
                   ((ex ...) tfi))]
 
   ;; Imported function is easy
   [-----------------------------------------------------------
-   (⊢-module-func S C ((ex ...) (func tfi im)) ((ex ...) tfi))])
+   (⊢-module-func S i C ((ex ...) (func tfi im)) ((ex ...) tfi))])
 
 ;; Helper judgement to ensure that function declarations/definitions are valid
 ;; Ensures each function in the list matches its respective type under a the module type consisting only of the preceeding global definitions in the list
 (define-judgment-form WASMIndexTypes
-  #:contract (⊢-module-func-list S C (f ...) (((ex ...) tfi) ...))
+  #:contract (⊢-module-func-list S i C (f ...) (((ex ...) tfi) ...))
 
   [-----------------------------
-   (⊢-module-func-list S C () ())]
+   (⊢-module-func-list S i C () ())]
 
-  [(⊢-module-func S C f_1 ((ex_1 ...) tfi_1))
-   (⊢-module-func-list S C (f_2 ...) (((ex_2 ...) tfi_2) ...))
+  [(⊢-module-func S i C f_1 ((ex_1 ...) tfi_1))
+   (⊢-module-func-list S i C (f_2 ...) (((ex_2 ...) tfi_2) ...))
    ---------------------------------------------------------
-   (⊢-module-func-list S C (f_1 f_2 ...) (((ex_1 ...) tfi_1) ((ex_2 ...) tfi_2) ...))])
+   (⊢-module-func-list S i C (f_1 f_2 ...) (((ex_1 ...) tfi_1) ((ex_2 ...) tfi_2) ...))])
 
 ;; Validates the global variable definition and returns all exports and the type of the global
 (define-judgment-form WASMIndexTypes
-  #:contract (⊢-module-global S C glob ((ex ...) tg))
+  #:contract (⊢-module-global S i C glob ((ex ...) tg))
 
   [(where (mut? t) tg)
    ;; Can't have exports if global is mutable
    (side-condition ,(or (not (term mut?)) (null? (term (ex ...)))))
    ;; Worth looking into strengthening this
-   (⊢ S C (e ...) ((() () globals_1 φ_1) -> ((t a) () globals_2 φ_2)))
+   (⊢ S i C (e ...) ((() () globals_1 φ_1) -> ((t a) () globals_2 φ_2)))
    -------------------------
-   (⊢-module-global S C
+   (⊢-module-global S i C
                     ((ex ...) (global tg (e ...)))
                     ((ex ...) tg))]
 
   [;; Can't import a mutable global
    (where (#f t) tg)
   -------------------------
-   (⊢-module-global S C
+   (⊢-module-global S i C
                     ((ex ...) (global tg im))
                     ((ex ...) tg))])
 
 ;; Helper judgement to ensure that global variable definitions are valid
 ;; Ensures each global in the list matches its respective type under a the module type consisting only of the preceeding global definitions in the list
 (define-judgment-form WASMIndexTypes
-  #:contract (⊢-module-global-list S (glob ...) (((ex ...) tg) ...))
+  #:contract (⊢-module-global-list S i (glob ...) (((ex ...) tg) ...))
 
   [-----------------------------
-   (⊢-module-global-list S () ())]
+   (⊢-module-global-list S i () ())]
 
-  [(⊢-module-global S ((func ()) (global (tg ...)) (table) (memory) (local ()) (label ()) (return)) glob_1 ((ex_1 ...) tg_1))
-   (⊢-module-global-list S (glob ...) (((ex ...) tg) ...))
+  [(⊢-module-global S i ((func ()) (global (tg ...)) (table) (memory) (local ()) (label ()) (return)) glob_1 ((ex_1 ...) tg_1))
+   (⊢-module-global-list S i (glob ...) (((ex ...) tg) ...))
    ------------------------------------------------------------------------------------------------------------------------
-   (⊢-module-global-list S (glob ... glob_1) (((ex ...) tg) ... ((ex_1 ...) tg_1)))]
+   (⊢-module-global-list S i (glob ... glob_1) (((ex ...) tg) ... ((ex_1 ...) tg_1)))]
   )
 
 ;; Helper function to ensure a table is well-formed
@@ -124,35 +131,35 @@
 
 ;; Validates all definitions in the module against the types declared in the module
 (define-judgment-form WASMIndexTypes
-  #:contract (⊢-module S m C)
+  #:contract (⊢-module S i m C)
 
   [(where ((func (tfi ...)) (global (tg ...)) (table (i (tfi_2 ...))) (memory j) (local ()) (label ()) (return)) C)
-   (⊢-module-func-list S C (f ...) (((ex_1_ ...) tfi) ...))
-   (⊢-module-global-list S (glob ...) (((ex_2_ ...) tg) ...))
-   (⊢-module-table C tab ((ex_3_ ...) (i (tfi_2 ...))))
+   (⊢-module-func-list S i C (f ...) (((ex_1_ ...) tfi) ...))
+   (⊢-module-global-list S i (glob ...) (((ex_2_ ...) tg) ...))
+   (⊢-module-table C tab ((ex_3_ ...) (i_1 (tfi_2 ...))))
    (⊢-module-mem C mem ((ex_4_ ...) j))
    ------------------------------------
-   (⊢-module S (module (f ...) (glob ...) (tab) (mem)) C)]
+   (⊢-module S i (module (f ...) (glob ...) (tab) (mem)) C)]
 
   [(where ((func (tfi ...)) (global (tg ...)) (table (i (tfi_2 ...))) (memory) (local ()) (label ()) (return)) C)
-   (⊢-module-func-list S C (f ...) (((ex_1_ ...) tfi) ...))
-   (⊢-module-global-list S (glob ...) (((ex_2_ ...) tg) ...))
-   (⊢-module-mem C tab ((ex_3_ ...) (i (tfi_2 ...))))
+   (⊢-module-func-list S i C (f ...) (((ex_1_ ...) tfi) ...))
+   (⊢-module-global-list S i (glob ...) (((ex_2_ ...) tg) ...))
+   (⊢-module-mem C tab ((ex_3_ ...) (i_1 (tfi_2 ...))))
    --------------------------------------------------
-   (⊢-module S (module (f ...) (glob ...) (tab) ()) C)]
+   (⊢-module S i (module (f ...) (glob ...) (tab) ()) C)]
 
   [(where ((func (tfi ...)) (global (tg ...)) (table) (memory j) (local ()) (label ()) (return)) C)
-   (⊢-module-func-list S C (f ...) (((ex_1_ ...) tfi) ...))
-   (⊢-module-global-list S (glob ...) (((ex_2_ ...) tg) ...))
+   (⊢-module-func-list S i C (f ...) (((ex_1_ ...) tfi) ...))
+   (⊢-module-global-list S i (glob ...) (((ex_2_ ...) tg) ...))
    (⊢-module-mem C mem ((ex_4_ ...) j))
    ------------------------------------
-   (⊢-module S (module (f ...) (glob ...) () (mem)) C)]
+   (⊢-module S i (module (f ...) (glob ...) () (mem)) C)]
 
-  [(⊢-module-func-list S C (f ...) (((ex_1_ ...) tfi) ...))
-   (⊢-module-global-list S (glob ...) (((ex_2_ ...) tg) ...))
+  [(⊢-module-func-list S i C (f ...) (((ex_1_ ...) tfi) ...))
+   (⊢-module-global-list S i (glob ...) (((ex_2_ ...) tg) ...))
    (where C ((func (tfi ...)) (global (tg ...)) (table) (memory) (local ()) (label ()) (return)))
    ---------------------------------------------------------------------------------------------
-   (⊢-module S (module (f ...) (glob ...) () ()) C)]
+   (⊢-module S i (module (f ...) (glob ...) () ()) C)]
   )
 
 

--- a/IndexTypingRules.rkt
+++ b/IndexTypingRules.rkt
@@ -55,71 +55,71 @@
   [(erase-mut t) t])
 
 (define-judgment-form WASMIndexTypes
-  #:contract (⊢ S C (e ...) tfi)
+  #:contract (⊢ S i C (e ...) tfi)
 
   [;; a fresh
-   (⊢ S C ((t const c)) ((() locals globals φ)
-                         -> (((t a)) locals globals ((φ (t a)) (eq a (t c))))))]
+   (⊢ S i C ((t const c)) ((() locals globals φ)
+                           -> (((t a)) locals globals ((φ (t a)) (eq a (t c))))))]
 
   [(side-condition (satisfies φ (empty (ne a_2 (i32 0)))))
    ;; a_3 fresh
    -------------------------------------------------------
-   (⊢ S C ((t div/unsafe)) ((((t a_1) (t a_2)) locals globals φ)
-                            -> (((t a_3)) locals globals ((φ (t a_3)) (eq a_3 (div a_1 a_2))))))]
+   (⊢ S i C ((t div/unsafe)) ((((t a_1) (t a_2)) locals globals φ)
+                              -> (((t a_3)) locals globals ((φ (t a_3)) (eq a_3 (div a_1 a_2))))))]
 
   [(where (binop_!_1 binop_!_1) (binop div/unsafe))
    ;; a_3 fresh
    ------------------------------------------------
-   (⊢ S C ((t binop)) ((((t a_1) (t a_2)) locals globals φ)
-                       -> (((t a_3)) locals globals ((φ (t a_3)) (eq a_3 (binop a_1 a_2))))))]
+   (⊢ S i C ((t binop)) ((((t a_1) (t a_2)) locals globals φ)
+                         -> (((t a_3)) locals globals ((φ (t a_3)) (eq a_3 (binop a_1 a_2))))))]
 
   [;; a_2 fresh
-   (⊢ S C ((t testop)) ((((t a)) locals globals φ)
-                        -> (((t a_2)) locals globals
-                                    ((φ (t a_2)) (and (and (testop a) (eq a_2 1))
-                                                      (and (not (testop a)) (eq a_2 0)))))))]
+   (⊢ S i C ((t testop)) ((((t a)) locals globals φ)
+                          -> (((t a_2)) locals globals
+                                        ((φ (t a_2)) (and (and (testop a) (eq a_2 1))
+                                                          (and (not (testop a)) (eq a_2 0)))))))]
 
   [;; a_3 fresh
-   (⊢ S C ((t relop)) ((((t a_1) (t a_2)) locals globals φ)
-                       -> (((t a_3)) locals globals
-                                     ((φ (t a_3)) (and (and (relop a_1 a_2) (eq a_3 1))
-                                                       (and (not (relop a_1 a_2)) (eq a_3 0)))))))]
+   (⊢ S i C ((t relop)) ((((t a_1) (t a_2)) locals globals φ)
+                         -> (((t a_3)) locals globals
+                                       ((φ (t a_3)) (and (and (relop a_1 a_2) (eq a_3 1))
+                                                         (and (not (relop a_1 a_2)) (eq a_3 0)))))))]
 
-  [(⊢ S C ((unreachable)) tfi)]
+  [(⊢ S i C ((unreachable)) tfi)]
 
-  [(⊢ S C ((nop)) ((() locals globals φ) -> (() locals globals φ)))]
+  [(⊢ S i C ((nop)) ((() locals globals φ) -> (() locals globals φ)))]
 
-  [(⊢ S C ((drop)) (((ti ... (t a)) locals globals φ) -> ((ti ...) locals globals φ)))]
+  [(⊢ S i C ((drop)) (((ti ... (t a)) locals globals φ) -> ((ti ...) locals globals φ)))]
 
-  [(⊢ S C ((select)) ((((t a_1) (t a_2) (i32 c)) locals globals φ)
-                      -> (((t a_3)) locals globals
-                                    ((φ (t a_3)) (and (and (eqz c) (eq a_3 a_1))
-                                                      (and (not (eqz c)) (eq a_3 a_2)))))))]
+  [(⊢ S i C ((select)) ((((t a_1) (t a_2) (i32 c)) locals globals φ)
+                        -> (((t a_3)) locals globals
+                                      ((φ (t a_3)) (and (and (eqz c) (eq a_3 a_1))
+                                                        (and (not (eqz c)) (eq a_3 a_2)))))))]
 
   [(where (ticond_1 -> ticond_2) tfi)
    (where C_2 (in-label C_1 ticond_2))
-   (⊢ S C_2 (e ...) tfi)
+   (⊢ S i C_2 (e ...) tfi)
    -----------------------------------
-   (⊢ S C_1 ((block tfi (e ...))) tfi)]
+   (⊢ S i C_1 ((block tfi (e ...))) tfi)]
 
   [(where (ticond_1 -> ticond_2) tfi)
    (where C_2 (in-label C_1 ticond_1))
-   (⊢ S C_2 (e ...) tfi)
+   (⊢ S i C_2 (e ...) tfi)
    ----------------------------------
-   (⊢ S C_1 ((loop tfi (e ...))) tfi)]
+   (⊢ S i C_1 ((loop tfi (e ...))) tfi)]
 
   [(where (((ti_1 ...) locals_1 globals_1 φ_1)
            -> ticond_2) tfi)
    (where C_2 (in-label C_1 ticond_2))
-   (⊢ S C_2 (e_1 ...) (((ti_1 ...) locals_1 globals_1 (φ_1 (neq a (i32 0)))) -> ticond_2))
-   (⊢ S C_2 (e_2 ...) (((ti_1 ...) locals_1 globals_1 (φ_1 (eqz a))) -> ticond_2))
+   (⊢ S i C_2 (e_1 ...) (((ti_1 ...) locals_1 globals_1 (φ_1 (neq a (i32 0)))) -> ticond_2))
+   (⊢ S i C_2 (e_2 ...) (((ti_1 ...) locals_1 globals_1 (φ_1 (eqz a))) -> ticond_2))
    ------------------------------------
-   (⊢ S C_1 ((if tfi (e_1 ...) (e_2 ...)))
+   (⊢ S i C_1 ((if tfi (e_1 ...) (e_2 ...)))
       (((ti_1 ... (i32 a)) locals_1 globals_1 φ_1) -> ticond_2))]
 
   [(label-types (ticond ...) (j) ((ti ...) φ_1))
    ---------------------------------------------
-   (⊢ S (_ _ _ _ _ (label (ticond  ...)) _)
+   (⊢ S i (_ _ _ _ _ (label (ticond  ...)) _)
       ((br j))
       (((ti_1 ... ti ...) locals globals φ_1)
        -> ((ti_2 ...) locals globals φ_2)))]
@@ -127,7 +127,7 @@
   ;; TODO: Should be (i32 a) not (t a)
   [(label-types (ticond ...) (j) ((ti ...) φ_1))
    ---------------------------------------------
-   (⊢ S (_ _ _ _ _ (label (ticond  ...)) _)
+   (⊢ S i (_ _ _ _ _ (label (ticond  ...)) _)
       ((br-if j))
       (((ti ... (t a)) locals globals φ_1)
        -> ((ti ...) locals globals (φ_1 (eqz a)))))]
@@ -136,14 +136,14 @@
   ;; TODONE: Hopefully
   [(label-types (ticond ...) (j ...) ((ti_3 ...) φ_1))
    ----------------------------------------
-   (⊢ S ((_ _ _ _ (label (ticond ...)) _ _))
+   (⊢ S i ((_ _ _ _ (label (ticond ...)) _ _))
       ((br-table (j ...)))
       (((ti_1 ... ti_3 ... (i32 a)) locals globals φ_1)
        -> ((ti_2 ...) locals globals φ_2)))]
 
   [(side-condition (satisfies φ_1 φ))
    --------------------------------------------------
-   (⊢ S (_ _ _ _ _ _ (return ((ti ...) _ globals φ)))
+   (⊢ S i (_ _ _ _ _ _ (return ((ti ...) _ globals φ)))
       ((return))
       (((ti_1 ... ti ...) locals globals φ_1)
        -> ticond))]
@@ -156,7 +156,8 @@
    (where φ_3 (extend φ φ_2))
    (side-condition (satisfies φ φ_1))
    ----------------------------------------------
-   (⊢ S ((func (tfi ...)) _ _ _ _ _ _) ((call j))
+   (⊢ S i ((func (tfi ...)) _ _ _ _ _ _)
+      ((call j))
       (((ti_1 ...) locals globals_1 φ)
        -> ((ti_2 ...) locals globals_2 φ_3)))]
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -165,7 +166,7 @@
            -> ((ti_2 ...) _ globals_2 φ_3)) tfi)
    (side-condition (satisfies φ_1 φ_2))
    ------------------------------------
-   (⊢ S (_ _ (table j _) _ _ _ _)
+   (⊢ S i (_ _ (table j _) _ _ _ _)
       ((call-indirect tfi))
       (((ti_1 ... (i32 a)) locals_1 globals_1 φ_1)
        -> ((ti_2 ...) locals_1 globals_2 φ_3)))]
@@ -174,7 +175,7 @@
    (side-condition (satisfies φ_1 φ_2))
    (side-condition (valid-table-call tfi_2 a (tfi ...) φ_1))
    ---------------------------------------------------------
-   (⊢ S (_ _ (table (j (tfi ...))) _ _ _ _)
+   (⊢ S i (_ _ (table (j (tfi ...))) _ _ _ _)
       ((call-indirect/unsafe tfi_2))
       (((ti_1 ... (i32 a)) locals_1 globals_1 φ_1)
        -> ((ti_2 ...) locals_1 globals_2 φ_3)))]
@@ -183,7 +184,7 @@
    (where (t_2 a) (do-get locals j))
    ;; a_2 fresh
    ---------------------------------
-   (⊢ S (_ _ _ _ (local (t ...)) _ _)
+   (⊢ S i (_ _ _ _ (local (t ...)) _ _)
       ((get-local j))
       ((() locals globals φ)
        -> (((t_2 a_2)) locals globals ((φ (t_2 a_2)) (eq a_2 a)))))]
@@ -192,7 +193,7 @@
    (where locals_2 (do-set locals_1 j (t_2 a_2)))
    ;; a_2 fresh
    ----------------------------------------------
-   (⊢ S (_ _ _ _ (local (t ...)) _ _)
+   (⊢ S i (_ _ _ _ (local (t ...)) _ _)
       ((set-local j))
       ((((t_2 a)) locals_1 globals φ)
        -> (() locals_2 globals ((φ (t_2 a_2)) (eq a_2 a)))))]
@@ -201,17 +202,16 @@
    (where locals_2 (do-set locals_1 j (t_2 a_2)))
    ;; a_2 fresh
    ----------------------------------------------
-   (⊢ S (_ _ _ _ (local (t ...)) _ _)
+   (⊢ S i (_ _ _ _ (local (t ...)) _ _)
       ((tee-local j))
       ((((t_2 a)) locals_1 globals φ)
        -> (((t_2 a)) locals_2 globals ((φ (t_2 a_2)) (eq a_2 a)))))]
 
   ;; TODO: if not mut, lookup value?
-  [(where tg_2 (do-get (tg ...) j))
-   (where t_2 (erase-mut tg_2))
+  [(where (mut? t_2) (do-get (tg ...) j))
    (where (t_2 a) (do-get globals j))
    --------------------------------------
-   (⊢ S (_ (global (tg ...)) _ _ _ _ _ _)
+   (⊢ S i (_ (global (tg ...)) _ _ _ _ _ _)
       ((get-global j))
       ((() locals globals φ)
        -> (((t_2 a_2)) locals globals ((φ (t_2 a_2)) (eq a_2 a)))))]
@@ -219,7 +219,7 @@
   [(where (mut t_2) (do-get (tg ...) j))
    (where globals_2 (do-set globals_1 j (t_2 a_2)))
    ------------------------------------------------
-   (⊢ S (_ (global (tg ...)) _ _ _ _ _ _)
+   (⊢ S i (_ (global (tg ...)) _ _ _ _ _ _)
       ((set-global j))
       ((((t_2 a)) locals globals_1 φ)
        -> (() locals globals_2 ((φ (t_2 a_2)) (eq a_2 a)))))]
@@ -232,8 +232,8 @@
                                         (ge (add a (i32 j_2)) (i32 0))))))
    ;; a_2 fresh
    -----------------------------------------------------------------------
-   (⊢ S C ((t load/unsafe j_1 j_2)) ((((i32 a)) locals globals φ_1)
-                                     -> (((t a_2)) locals globals (φ_1 (t a_2)))))]
+   (⊢ S i C ((t load/unsafe j_1 j_2)) ((((i32 a)) locals globals φ_1)
+                                       -> (((t a_2)) locals globals (φ_1 (t a_2)))))]
 
   [(where (_ _ _ (memory j) _ _ _) C)
    (side-condition ,(< (expt 2 (term j_1))
@@ -243,8 +243,8 @@
                                         (ge (add a (i32 j_2)) (i32 0))))))
    ;; a_2 fresh
    -----------------------------------------------------------------------
-   (⊢ S C ((t load/unsafe (tp sz) j_1 j_2)) ((((i32 a)) locals globals φ_1)
-                                             -> (((t a_2)) locals globals (φ_1 (t a_2)))))]
+   (⊢ S i C ((t load/unsafe (tp sz) j_1 j_2)) ((((i32 a)) locals globals φ_1)
+                                               -> (((t a_2)) locals globals (φ_1 (t a_2)))))]
 
   [(where (_ _ _ (memory j) _ _ _) C)
    (side-condition ,(< (expt 2 (term j_1))
@@ -253,8 +253,8 @@
                                    (and (le (add (add a (i32 j_2)) (i32 ,(/ (type-width (term t)) 8))) (i32 j))
                                         (ge (add a (i32 j_2)) (i32 0))))))
    -------------------------------------------------------------------------
-   (⊢ S C ((t store/unsafe j_1 j_2)) ((((i32 a) (t a_1)) locals globals φ_1)
-                                      -> (() locals globals φ_1)))]
+   (⊢ S i C ((t store/unsafe j_1 j_2)) ((((i32 a) (t a_1)) locals globals φ_1)
+                                        -> (() locals globals φ_1)))]
 
   ;; TODO: no floats yet so not included in side-condition
   [(where (_ _ _ (memory j) _ _ _) C)
@@ -264,29 +264,29 @@
                                    (and (le (add (add a (i32 j_2)) (i32 ,(/ (type-width (term t) (term tp)) 8))) (i32 j))
                                         (ge (add a (i32 j_2)) (i32 0))))))
    ------------------------------------------------------------------------------
-   (⊢ S C ((t store/unsafe (tp) j_1 j_2)) ((((i32 a) (t a_1)) locals globals φ_1)
-                                           -> (() locals globals φ_1)))]
+   (⊢ S i C ((t store/unsafe (tp) j_1 j_2)) ((((i32 a) (t a_1)) locals globals φ_1)
+                                             -> (() locals globals φ_1)))]
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
   [-----------------------------------------------------------
-   (⊢ S C () ((() locals globals φ) -> (() locals globals φ)))]
+   (⊢ S i C () ((() locals globals φ) -> (() locals globals φ)))]
 
-  [(⊢ S C (e_1 ...) (ticond_1 -> ((ti_2 ...) locals globals φ_2)))
-   (⊢ S C (e_2) (((ti_2 ...) locals globals φ_3) -> ticond_3))
+  [(⊢ S i C (e_1 ...) (ticond_1 -> ((ti_2 ...) locals globals φ_2)))
+   (⊢ S i C (e_2) (((ti_2 ...) locals globals φ_3) -> ticond_3))
    (side-condition (satisfies φ_2 φ_3))
    --------------------------------------------
-   (⊢ S C (e_1 ... e_2) (ticond_1 -> ticond_3))]
+   (⊢ S i C (e_1 ... e_2) (ticond_1 -> ticond_3))]
 
-  [(⊢ S C (e ...) (((ti_1 ...) locals globals φ_1)
-                   -> ((ti_2 ...) locals globals φ_2)))
+  [(⊢ S i C (e ...) (((ti_1 ...) locals globals φ_1)
+                     -> ((ti_2 ...) locals globals φ_2)))
    ------------------------------------------------------
-   (⊢ S C (e ...) (((ti ... ti_1 ...) locals globals φ_1)
-                   -> ((ti ... ti_2 ...) locals globals φ_2)))]
+   (⊢ S i C (e ...) (((ti ... ti_1 ...) locals globals φ_1)
+                     -> ((ti ... ti_2 ...) locals globals φ_2)))]
 
   ;; Subtyping
   ;; TODO: This here?
-  [(⊢ S C (e ...) tfi_2)
+  [(⊢ S i C (e ...) tfi_2)
    (<: tfi_1 tfi_2)
    ---------------------
-   (⊢ S C (e ...) tfi_1)])
+   (⊢ S i C (e ...) tfi_1)])

--- a/Tests/IndexModuleTypeTests.rkt
+++ b/Tests/IndexModuleTypeTests.rkt
@@ -35,7 +35,7 @@
                                 (return ,ticond5))))
 
   (define deriv1
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                     ((get-local 0))
                     (,ticond1 -> ,ticond2))
                 #f
@@ -44,7 +44,7 @@
   (test-judgment-holds ⊢ deriv1)
 
   (define deriv2_0
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                                  ((get-local 1))
                                  (,ticond2_1 -> ,ticond3_1))
                              #f
@@ -53,7 +53,7 @@
   (test-judgment-holds ⊢ deriv2_0)
 
   (define deriv2_1
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                                  ((get-local 1))
                                  (,ticond2 -> ,ticond3))
                              #f
@@ -62,7 +62,7 @@
   (test-judgment-holds ⊢ deriv2_1)
   
   (define deriv2
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                     ((get-local 0) (get-local 1))
                     (,ticond1 -> ,ticond3))
                 #f
@@ -71,7 +71,7 @@
   (test-judgment-holds ⊢ deriv2)
 
   (define deriv3_0
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                                  ((i32 add))
                                  (,ticond3 -> ,ticond4))
                              #f
@@ -80,7 +80,7 @@
   (test-judgment-holds ⊢ deriv3_0)
 
   (define deriv3
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                     ((get-local 0) (get-local 1) (i32 add))
                     (,ticond1 -> ,ticond4))
                 #f
@@ -94,7 +94,7 @@
                 (list)))
 
   (define deriv4
-    (derivation `(⊢ ,dummy-store ,context1-inner
+    (derivation `(⊢ ,dummy-store 0 ,context1-inner
                     ((get-local 0) (get-local 1) (i32 add))
                     (,ticond1 -> ,ticond5))
                 #f
@@ -111,7 +111,7 @@
                              (() (,ticond0 -> ,ticond6))))
 
   (define deriv5
-    (derivation `(⊢-module-func ,dummy-store ,context1
+    (derivation `(⊢-module-func ,dummy-store 0 ,context1
                                 (() (func (,ticond0 -> ,ticond6)
                                           (local () ((get-local 0) (get-local 1) (i32 add)))))
                                 (() (,ticond0 -> ,ticond6)))

--- a/Tests/IndexTypeTests.rkt
+++ b/Tests/IndexTypeTests.rkt
@@ -10,26 +10,26 @@
   (define empty-context `((func ()) (global ()) (table) (memory) (local ()) (label ()) (return)))
   
   #;(test-judgment-holds ⊢
-   (derivation `(⊢ ,dummy-store ,empty-context ((if ((((i32 a) (i32 b)) empty) -> ((i32 c) empty))
+   (derivation `(⊢ ,dummy-store 0 ,empty-context ((if ((((i32 a) (i32 b)) empty) -> ((i32 c) empty))
                                        (i32 div/unsafe)
                                        (i32 const -1))
                    (((i32 a) (i32 b) (i32 b)) (((empty (a : i32)) (b : i32)) (>= b 0)))
                    ))))
 
   (test-judgment-holds ⊢
-                       (derivation `(⊢ ,dummy-store ,empty-context ((i32 sub))
-                                             ((((i32 b) (i32 c)) () ()
-                                               ((((empty (i32 a)) (i32 b)) (i32 c))
-                                                (not (eq b c))))
-                                              ->
-                                              (((i32 d)) () ()
-                                               ((((((empty (i32 a)) (i32 b)) (i32 c))
-                                                  (not (eq b c))) (i32 d)) (eq d (sub b c))))))
-                                         #f
-                                         (list)))
+                       (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 sub))
+                                       ((((i32 b) (i32 c)) () ()
+                                         ((((empty (i32 a)) (i32 b)) (i32 c))
+                                          (not (eq b c))))
+                                        ->
+                                        (((i32 d)) () ()
+                                         ((((((empty (i32 a)) (i32 b)) (i32 c))
+                                            (not (eq b c))) (i32 d)) (eq d (sub b c))))))
+                                   #f
+                                   (list)))
 
   (test-judgment-holds ⊢
-                       (derivation `(⊢ ,dummy-store ,empty-context ((i32 sub))
+                       (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 sub))
                                        ((((i32 a) (i32 b) (i32 c)) () ()
                                          ((((empty (i32 a)) (i32 b)) (i32 c))
                                           (not (eq b c))))
@@ -39,7 +39,7 @@
                                            (not (eq b c))) (i32 d)) (eq d (sub b c))))))
                                    #f
                                    (list
-                             (derivation `(⊢ ,dummy-store ,empty-context ((i32 sub))
+                             (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 sub))
                                              ((((i32 b) (i32 c)) () ()
                                                ((((empty (i32 a)) (i32 b)) (i32 c))
                                                 (not (eq b c))))
@@ -51,7 +51,7 @@
                                          (list)))))
 
   #;(test-judgment-holds ⊢
-                       (derivation `(⊢ ,dummy-store ,empty-context ((i32 div/unsafe))
+                       (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 div/unsafe))
                                 ((((i32 a) (i32 d)) () ()
                                   ((((((empty (i32 a)) (i32 b)) (i32 c)) (i32 d))
                                      (not (eq d (i32 0)))) (eq d (sub b c))))
@@ -63,7 +63,7 @@
                             (list)))
 
   (test-judgment-holds ⊢
-   (derivation `(⊢ ,dummy-store ,empty-context ((i32 sub) (i32 div/unsafe))
+   (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 sub) (i32 div/unsafe))
                    ((((i32 a) (i32 b) (i32 c)) () ()
                      ((((empty (i32 a)) (i32 b)) (i32 c))
                       (not (eq b c))))
@@ -73,17 +73,17 @@
                          (not (eq d (i32 0)))) (eq d (sub b c))) (i32 e)) (eq e (div a d))))))
                #f
                (list
-                (derivation `(⊢ ,dummy-store ,empty-context ((i32 sub))
-                                       ((((i32 a) (i32 b) (i32 c)) () ()
-                                         ((((empty (i32 a)) (i32 b)) (i32 c))
-                                          (not (eq b c))))
-                                        ->
-                                        (((i32 a) (i32 d)) () ()
-                                         ((((((empty (i32 a)) (i32 b)) (i32 c))
-                                           (not (eq b c))) (i32 d)) (eq d (sub b c))))))
+                (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 sub))
+                                ((((i32 a) (i32 b) (i32 c)) () ()
+                                  ((((empty (i32 a)) (i32 b)) (i32 c))
+                                   (not (eq b c))))
+                                 ->
+                                 (((i32 a) (i32 d)) () ()
+                                  ((((((empty (i32 a)) (i32 b)) (i32 c))
+                                     (not (eq b c))) (i32 d)) (eq d (sub b c))))))
                                    #f
                                    (list
-                             (derivation `(⊢ ,dummy-store ,empty-context ((i32 sub))
+                             (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 sub))
                                              ((((i32 b) (i32 c)) () ()
                                                ((((empty (i32 a)) (i32 b)) (i32 c))
                                                 (not (eq b c))))
@@ -93,7 +93,7 @@
                                                   (not (eq b c))) (i32 d)) (eq d (sub b c))))))
                                          #f
                                          (list))))
-                (derivation `(⊢ ,dummy-store ,empty-context ((i32 div/unsafe))
+                (derivation `(⊢ ,dummy-store 0 ,empty-context ((i32 div/unsafe))
                                 ((((i32 a) (i32 d)) () ()
                                   ((((((empty (i32 a)) (i32 b)) (i32 c)) (i32 d))
                                      (not (eq d (i32 0)))) (eq d (sub b c))))
@@ -105,7 +105,7 @@
                             (list)))))
 
   ;; This case worked in Adam's brain, but not in practice due to possible integer overflow
-  #;(test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func
+  #;(test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0 ((func
                                            (((((i32 a)) () () ((empty (i32 a)) (lt a (i32 0)))) -> (((i32 b)) () () (((empty (i32 a)) (i32 b)) (gt b (i32 0)))))
                                             ((((i32 a)) () () (empty (i32 a))) -> (((i32 b)) () () (((empty (i32 a)) (i32 b)) (eq b (add a (i32 1))))))
                                             ((((i32 a)) () () (empty (i32 a))) -> (((i32 b)) () () ((empty (i32 a)) (i32 b))))
@@ -123,7 +123,8 @@
                                      #f
                                      (list)))
 
-  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func
+  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0
+                                         ((func
                                            (((((i32 a)) () () ((empty (i32 a)) (lt a (i32 0)))) -> (((i32 b)) () () (((empty (i32 a)) (i32 b)) (gt b (i32 0)))))
                                             ((((i32 a)) () () (empty (i32 a))) -> (((i32 b)) () () (((empty (i32 a)) (i32 b)) (gt b a))))
                                             ((((i32 a)) () () (empty (i32 a))) -> (((i32 b)) () () ((empty (i32 a)) (i32 b))))
@@ -143,7 +144,8 @@
                                      #f
                                      (list)))
 
-  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func ())
+  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0
+                                         ((func ())
                                           (global ())
                                           (table)
                                           (memory 4096)
@@ -156,7 +158,8 @@
                                      #f
                                      (list)))
 
-  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func ())
+  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0
+                                         ((func ())
                                           (global ())
                                           (table)
                                           (memory 4096)
@@ -169,7 +172,8 @@
                                      #f
                                      (list)))
 
-  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func ())
+  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0
+                                         ((func ())
                                           (global ())
                                           (table)
                                           (memory 4096)
@@ -182,7 +186,8 @@
                                      #f
                                      (list)))
 
-  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func ())
+  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0
+                                         ((func ())
                                           (global ())
                                           (table)
                                           (memory)
@@ -194,7 +199,8 @@
                                           -> (((i32 d)) ((i32 c)) () ((((((empty (i32 a)) (i32 b)) (i32 c)) (eq c a)) (i32 d)) (eq d c)))))
                                      #f
                                      (list
-                                      (derivation `(⊢ ,dummy-store ((func ())
+                                      (derivation `(⊢ ,dummy-store 0
+                                                      ((func ())
                                                        (global ())
                                                        (table)
                                                        (memory)
@@ -206,7 +212,8 @@
                                                        -> (() ((i32 c)) () ((((empty (i32 a)) (i32 b)) (i32 c)) (eq c a)))))
                                                   #f
                                                   (list))
-                                      (derivation `(⊢ ,dummy-store ((func ())
+                                      (derivation `(⊢ ,dummy-store 0
+                                                      ((func ())
                                                        (global ())
                                                        (table)
                                                        (memory)
@@ -219,7 +226,8 @@
                                                   #f
                                                   (list)))))
 
-  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
+  (test-judgment-holds ⊢ (derivation `(⊢ ,dummy-store 0
+                                         ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
                                                   -> (((i32 c)) () () ((empty (i32 c)) (gt c b))))))
                                           (global ())
                                           (table)
@@ -232,7 +240,8 @@
                                           -> (((i32 d)) () () (((((((empty (i32 a)) (i32 b)) (gt b (i32 0))) (i32 c)) (gt c b)) (i32 d)) (eq d (div a c))))))
                                      #f
                                      (list
-                                      (derivation `(⊢ ,dummy-store ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
+                                      (derivation `(⊢ ,dummy-store 0
+                                                      ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
                                                                -> (((i32 c)) () () ((empty (i32 c)) (gt c b))))))
                                                        (global ())
                                                        (table)
@@ -245,7 +254,8 @@
                                                        -> (((i32 a) (i32 c)) () () (((((empty (i32 a)) (i32 b)) (gt b (i32 0))) (i32 c)) (gt c b)))))
                                                   #f
                                                   (list
-                                                   (derivation `(⊢ ,dummy-store ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
+                                                   (derivation `(⊢ ,dummy-store 0
+                                                                   ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
                                                                             -> (((i32 c)) () () ((empty (i32 c)) (gt c b))))))
                                                                     (global ())
                                                                     (table)
@@ -258,7 +268,8 @@
                                                                     -> (((i32 c)) () () (((((empty (i32 a)) (i32 b)) (gt b (i32 0))) (i32 c)) (gt c b)))))
                                                                #f
                                                                (list))))
-                                      (derivation `(⊢ ,dummy-store ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
+                                      (derivation `(⊢ ,dummy-store 0
+                                                      ((func (((((i32 b)) () () ((empty (i32 b)) (gt b (i32 0))))
                                                                -> (((i32 c)) () () ((empty (i32 c)) (gt c b))))))
                                                        (global ())
                                                        (table)


### PR DESCRIPTION
* Typing rule for `call cl` also needs to be updated to differentiate between same module and different module calls.